### PR TITLE
Say hello in russian

### DIFF
--- a/frontend/src/pages/ChatPage.jsx
+++ b/frontend/src/pages/ChatPage.jsx
@@ -37,8 +37,10 @@ const ChatPage = () => {
       };
 
       const handleNewChannel = (newChannel) => {
+        // При получении события создания канала по сокету
+        // добавляем канал, но НЕ переключаемся на него.
+        // Переключение выполняется только инициатором в createChannel.fulfilled
         dispatch(addChannel(newChannel));
-        dispatch(setCurrentChannel(newChannel.id));
       };
 
       const handleRemoveChannel = (channelId) => {


### PR DESCRIPTION
Prevent non-initiators from automatically switching to a new channel upon creation, fixing the 'only initiator is switched to new channel' test.

The test `only initiator is switched to new channel` failed because all connected clients were automatically switched to the newly created channel. This change ensures that only the client initiating the channel creation switches to it, while other clients simply add it to their list.

---
<a href="https://cursor.com/background-agent?bcId=bc-dafec671-737d-4abf-ad27-b96f9ec78495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dafec671-737d-4abf-ad27-b96f9ec78495">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

